### PR TITLE
Render doctest block as code block

### DIFF
--- a/src/sphinx_ext_mystmd/transform.py
+++ b/src/sphinx_ext_mystmd/transform.py
@@ -343,7 +343,7 @@ class MySTNodeVisitor(Visitor):
         return SkipChildren
 
     def visit_doctest_block(self, node):
-        logger.warning("`doctest_block` node not implemented")
+        self.push_myst_node({"type": "code", "value": str(node.children[0])}, node)
         return SkipChildren
 
     def visit_table(self, node):


### PR DESCRIPTION
Fixes "WARNING: `doctest_block` node not implemented". Re-using the same code from `literal_block` here:

https://github.com/jupyter-book/sphinx-ext-mystmd/blob/51277dbb97f2fbfd7a1e94538ef47159cea804fb/src/sphinx_ext_mystmd/transform.py#L418-L420

For example, for my PR at https://github.com/weiji14/cog3pio/pull/35 where I'm trying to render a NumPy-style docstring like this:

```python
    """
    Examples
    --------
    Read a GeoTIFF from a HTTP url into a numpy.ndarray:

    >>> from cog3pio import read_geotiff
    ...
    >>> array = read_geotiff("https://github.com/pka/georaster/raw/v0.2.0/data/tiff/float32.tif")
    >>> array.shape
    (1, 20, 20)
    """
```

The rendering should look something like this:

![image](https://github.com/user-attachments/assets/bc37e24b-ee3c-4b2e-9f74-0cc3861abb58)

Not sure yet how to add syntax highlighting, open to tips!